### PR TITLE
[cuts-slurm] revise user's login name to a general format

### DIFF
--- a/cuts-slurm.el
+++ b/cuts-slurm.el
@@ -25,13 +25,10 @@
 (require 's)
 (require 'bui)
 
-;;; user defined parameters
-(setq slurm-user "yilung")
-
 ;; command to see your jobs
 (setq slurm-jobs-command
       (concat "squeue -u "
-              slurm-user
+              (user-real-login-name)
               " | awk '{print $1,$2,$3,$4,$5,$6,$7,$8}'"))
 
 ;; if you want to see all jobs instead


### PR DESCRIPTION
Dear the author of cuts.el:

Thanks for your effort. It makes my life with those machines much
funny now.

I play your package today, and I found that I need to manually change
my log-in Id, otherwise the command `(cuts-slurm-show-jobs)' returns
null.

I am not an expert in emacs lisp, but I google it and I found the
build-in function might solve this problem.

So, I purpose this change to your code. Feel free to question me and
we could consulting Emacs-china.org if necessary.

Sincerely,

Ran